### PR TITLE
Upgrade runner version and rocm version to unblock CI.

### DIFF
--- a/ghascale-rocm.Dockerfile
+++ b/ghascale-rocm.Dockerfile
@@ -27,9 +27,9 @@ RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.d
 RUN sudo groupadd -g 109 render
 
 RUN sudo apt update -y \
-    && sudo apt install python3-setuptools python3-wheel libpython3.10 \
+    && sudo apt install -y python3-setuptools python3-wheel libpython3.10 \
     && sudo usermod -a -G render,video runner \
     && wget https://repo.radeon.com/amdgpu-install/6.4.1/ubuntu/noble/amdgpu-install_6.4.60401-1_all.deb \
-    && sudo apt install ./amdgpu-install_6.4.60401-1_all.deb \
+    && sudo apt install -y ./amdgpu-install_6.4.60401-1_all.deb \
     && sudo apt update -y \
     && sudo apt install -y rocm-dev

--- a/ghascale-rocm.Dockerfile
+++ b/ghascale-rocm.Dockerfile
@@ -29,7 +29,7 @@ RUN sudo groupadd -g 109 render
 RUN sudo apt update -y \
     && sudo apt install -y python3-setuptools python3-wheel libpython3.10 \
     && sudo usermod -a -G render,video runner \
-    && wget https://repo.radeon.com/amdgpu-install/6.4.1/ubuntu/noble/amdgpu-install_6.4.60401-1_all.deb \
+    && wget https://repo.radeon.com/amdgpu-install/6.4.1/ubuntu/jammy/amdgpu-install_6.4.60401-1_all.deb \
     && sudo apt install -y ./amdgpu-install_6.4.60401-1_all.deb \
     && sudo apt update -y \
     && sudo apt install -y rocm-dev

--- a/ghascale-rocm.Dockerfile
+++ b/ghascale-rocm.Dockerfile
@@ -27,9 +27,9 @@ RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.d
 RUN sudo groupadd -g 109 render
 
 RUN sudo apt update -y \
-    && sudo apt install -y "linux-headers-$(uname -r)" "linux-modules-extra-$(uname -r)" \
+    && sudo apt install python3-setuptools python3-wheel libpython3.10 \
     && sudo usermod -a -G render,video runner \
-    && wget https://repo.radeon.com/amdgpu-install/6.2.2/ubuntu/jammy/amdgpu-install_6.2.60202-1_all.deb \
-    && sudo apt install -y ./amdgpu-install_6.2.60202-1_all.deb \
+    && wget https://repo.radeon.com/amdgpu-install/6.4/ubuntu/jammy/amdgpu-install_6.4.60400-1_all.deb \
+    && sudo apt install -y ./amdgpu-install_6.4.60400-1_all.deb \
     && sudo apt update -y \
     && sudo apt install -y rocm-dev

--- a/ghascale-rocm.Dockerfile
+++ b/ghascale-rocm.Dockerfile
@@ -29,7 +29,7 @@ RUN sudo groupadd -g 109 render
 RUN sudo apt update -y \
     && sudo apt install python3-setuptools python3-wheel libpython3.10 \
     && sudo usermod -a -G render,video runner \
-    && wget https://repo.radeon.com/amdgpu-install/6.4/ubuntu/jammy/amdgpu-install_6.4.60400-1_all.deb \
-    && sudo apt install -y ./amdgpu-install_6.4.60400-1_all.deb \
+    && wget https://repo.radeon.com/amdgpu-install/6.4.1/ubuntu/noble/amdgpu-install_6.4.60401-1_all.deb \
+    && sudo apt install ./amdgpu-install_6.4.60401-1_all.deb \
     && sudo apt update -y \
     && sudo apt install -y rocm-dev


### PR DESCRIPTION
This PR upgrades the rocm version, so that the rocm install works now and doesn't cause the CI to error out like we've been seeing for past few weeks: https://github.com/saienduri/docker-images/actions/runs/16212782122. This also allows the runner version to be bumped once CI succeeds as old version has been deprecated.